### PR TITLE
Removal of ids from the entities refs #1

### DIFF
--- a/lib/models/ability.dart
+++ b/lib/models/ability.dart
@@ -1,7 +1,6 @@
 class Ability{
-  int id;
   String name;
   String effect;
 
-  Ability(this.id, this.name);
+  Ability(this.name);
 }

--- a/lib/models/form.dart
+++ b/lib/models/form.dart
@@ -1,7 +1,6 @@
 class Form{
-  int id;
   String name;
   String formImage;
 
-  Form(this.id, this.name);
+  Form(this.name);
 }

--- a/lib/models/gameIndice.dart
+++ b/lib/models/gameIndice.dart
@@ -1,8 +1,7 @@
 class GameIndice{
-  int id;
   String name;
   List<String> moveLearnMethods;
   List<String> pokedexList;
 
-  GameIndice(this.id, this.name);
+  GameIndice(this.name);
 }

--- a/lib/models/item.dart
+++ b/lib/models/item.dart
@@ -1,11 +1,10 @@
 import 'itemAttribute.dart';
 
 class Item{
-  int id;
   String name;
   String category;
   String effect;
   List<ItemAttribute> attributes;
 
-  Item(this.id, this.name);
+  Item(this.name);
 }

--- a/lib/models/move.dart
+++ b/lib/models/move.dart
@@ -1,7 +1,6 @@
 class Move{
-  int id;
   String name;
   String effect;
 
-  Move(this.id, this.name);
+  Move(this.name);
 }


### PR DESCRIPTION
The entities don't need an id because they can be searched on the Api by the name.